### PR TITLE
Add Spotify OAuth2 auth helper and playlist scanner skill

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,41 @@
+COMMAND_SRC := $(CURDIR)/commands/spotify-scan.md
+COMMAND_DST := $(HOME)/.claude/commands/spotify-scan.md
+CONFIG_DIR  := $(HOME)/.config/sptfy
+
+.PHONY: install uninstall status
+
+install: ## Create symlink and config directory
+	@mkdir -p $(CONFIG_DIR)
+	@chmod 700 $(CONFIG_DIR)
+	@mkdir -p $(dir $(COMMAND_DST))
+	@ln -sf $(COMMAND_SRC) $(COMMAND_DST)
+	@echo "Installed:"
+	@echo "  Symlink: $(COMMAND_DST) -> $(COMMAND_SRC)"
+	@echo "  Config dir: $(CONFIG_DIR)"
+	@echo ""
+	@echo "Next: create a Spotify app at https://developer.spotify.com/dashboard"
+	@echo "  Set redirect URI to http://localhost:8765/callback"
+	@echo "  Then run: python3 spotify_auth.py login --client-id <YOUR_CLIENT_ID>"
+
+uninstall: ## Remove symlink (does not delete config/tokens)
+	@rm -f $(COMMAND_DST)
+	@echo "Removed symlink: $(COMMAND_DST)"
+	@echo "Config and tokens in $(CONFIG_DIR) were NOT deleted."
+	@echo "To fully clean up: rm -rf $(CONFIG_DIR)"
+
+status: ## Show install status
+	@echo "Command symlink:"
+	@if [ -L "$(COMMAND_DST)" ]; then \
+		echo "  $(COMMAND_DST) -> $$(readlink $(COMMAND_DST))"; \
+	else \
+		echo "  Not installed"; \
+	fi
+	@echo "Config directory:"
+	@if [ -d "$(CONFIG_DIR)" ]; then \
+		echo "  $(CONFIG_DIR) exists"; \
+		ls -la $(CONFIG_DIR)/ 2>/dev/null || true; \
+	else \
+		echo "  Not created"; \
+	fi
+	@echo "Auth status:"
+	@python3 $(CURDIR)/spotify_auth.py status 2>/dev/null || echo "  Not configured"

--- a/commands/spotify-scan.md
+++ b/commands/spotify-scan.md
@@ -1,0 +1,117 @@
+---
+allowed-tools: Bash(python3:*), Bash(curl:*)
+description: Scan Spotify playlists for radio show tracks and propose standalone replacements
+argument-hint: [playlist name]
+---
+
+# Spotify Playlist Scanner
+
+You are scanning the user's Spotify playlists to find tracks saved from radio show compilations (ASOT, Find Your Harmony, Corsten's Countdown, ABGT, etc.) and proposing swaps to standalone releases (extended mix, radio edit, or original).
+
+## Target playlist
+$ARGUMENTS
+
+## Step 1: Authenticate
+
+Get a valid Spotify access token:
+
+```bash
+python3 ~/dev/sptfy-auth/spotify_auth.py token
+```
+
+If this fails, tell the user to run `python3 ~/dev/sptfy-auth/spotify_auth.py login --client-id <CLIENT_ID>` first.
+
+Store the token in a variable for subsequent curl calls.
+
+## Step 2: Find the target playlist
+
+If `$ARGUMENTS` is provided, search for a matching playlist. Otherwise, list playlists and ask the user which one(s) to scan.
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" "https://api.spotify.com/v1/me/playlists?limit=50"
+```
+
+Paginate using the `next` URL if needed. Match playlist names case-insensitively.
+
+## Step 3: Fetch all tracks
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" "https://api.spotify.com/v1/playlists/$PLAYLIST_ID/tracks?limit=100"
+```
+
+Paginate through all tracks. For each track, capture:
+- Track ID and URI
+- Track name
+- Artists (names and IDs)
+- Album name, ID, and type (`album`, `single`, or `compilation`)
+- Track position in the playlist
+- Duration
+
+## Step 4: Identify radio show tracks
+
+Analyze each track's metadata to determine if it's from a radio show compilation rather than a standalone release. You are the detection engine — use your contextual understanding. Signals include:
+
+- **Album type is `compilation`** and the album name looks like a radio show episode (contains episode numbers, show names like "A State of Trance", "Find Your Harmony", "Group Therapy", "Corsten's Countdown", etc.)
+- **Track title contains a show-specific parenthetical** like `(ASOT 1263)`, `(FYHTOP2025)`, `(ABGT550)` — NOT standard mix descriptors like `(Extended Mix)`, `(Radio Edit)`, `(Remix)`, `(Original Mix)`, `(Club Mix)`, `(Acoustic)`, `(Live)`
+- **Track duration is unusually short** for an electronic track (under 3 minutes) which might indicate a radio show edit
+
+If uncertain about a track, include it for review — the user can always skip it.
+
+Present a summary of flagged tracks before proceeding.
+
+## Step 5: Search for standalone replacements
+
+For each flagged track:
+
+1. Extract the base song name by removing the show parenthetical from the title
+2. Identify the "real" artists — the show host (e.g. Armin van Buuren for ASOT, Andrew Rayel for FYH) may be listed as an artist on the compilation but not on the standalone release
+3. Search Spotify:
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" "https://api.spotify.com/v1/search?type=track&q=QUERY&limit=10"
+```
+
+Try these search queries in order:
+- `"{base song name}" artist:{real artist}` — most specific
+- `"{base song name} Extended Mix" artist:{real artist}` — look for extended
+- `"{base song name}"` — broader fallback
+
+4. From results, filter for tracks that are NOT from compilation albums. Prefer:
+   - Extended Mix > Radio Edit > Original (for trance/electronica, extended mixes are usually preferred)
+   - Same original artists
+   - From `album` or `single` type releases, not compilations
+
+## Step 6: Propose swaps
+
+For each flagged track with candidates found, present the swap proposal to the user using AskUserQuestion. Show:
+- Original: track name, artists, album, duration
+- Proposed replacement: track name, artists, album, duration
+
+Let the user approve or skip each swap. If multiple candidates exist, let them choose.
+
+## Step 7: Apply approved swaps
+
+For each approved swap:
+
+1. Remove the old track at its position:
+```bash
+curl -s -X DELETE -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"tracks":[{"uri":"OLD_TRACK_URI","positions":[POSITION]}]}' \
+  "https://api.spotify.com/v1/playlists/$PLAYLIST_ID/tracks"
+```
+
+2. Add the new track at the same position:
+```bash
+curl -s -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"uris":["NEW_TRACK_URI"],"position":POSITION}' \
+  "https://api.spotify.com/v1/playlists/$PLAYLIST_ID/tracks"
+```
+
+**Important**: Process swaps one at a time from the END of the playlist toward the beginning, so that position indices remain valid as you make changes.
+
+## Notes
+
+- The Spotify API rate limit is generous for personal use but if you get 429 responses, wait and retry
+- Track URIs look like `spotify:track:6rqhFgbbKwnb9MLmUQDhG6`
+- Album types: `album` (standard release), `single` (single/EP), `compilation` (various artists / radio shows)
+- All curl calls use the base URL `https://api.spotify.com/v1`

--- a/spotify_auth.py
+++ b/spotify_auth.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Spotify OAuth2 PKCE auth helper. Stdlib only — no pip dependencies."""
+
+import argparse
+import base64
+import hashlib
+import http.server
+import json
+import os
+import secrets
+import sys
+import time
+import urllib.parse
+import urllib.request
+import webbrowser
+
+CONFIG_DIR = os.path.expanduser("~/.config/sptfy")
+CONFIG_PATH = os.path.join(CONFIG_DIR, "config.json")
+TOKEN_PATH = os.path.join(CONFIG_DIR, "token.json")
+
+REDIRECT_URI = "http://localhost:8765/callback"
+AUTH_URL = "https://accounts.spotify.com/authorize"
+TOKEN_URL = "https://accounts.spotify.com/api/token"
+SCOPES = "playlist-read-private playlist-read-collaborative playlist-modify-private playlist-modify-public"
+
+
+def _ensure_config_dir():
+    os.makedirs(CONFIG_DIR, mode=0o700, exist_ok=True)
+
+
+def _read_json(path):
+    with open(path) as f:
+        return json.load(f)
+
+
+def _write_json(path, data):
+    _ensure_config_dir()
+    with open(os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600), "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def _generate_pkce():
+    verifier = secrets.token_urlsafe(64)
+    digest = hashlib.sha256(verifier.encode()).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
+    return verifier, challenge
+
+
+def _token_request(params):
+    data = urllib.parse.urlencode(params).encode()
+    req = urllib.request.Request(TOKEN_URL, data=data, method="POST")
+    req.add_header("Content-Type", "application/x-www-form-urlencoded")
+    with urllib.request.urlopen(req) as resp:
+        return json.loads(resp.read())
+
+
+def _refresh_token(config, token_data):
+    resp = _token_request({
+        "grant_type": "refresh_token",
+        "refresh_token": token_data["refresh_token"],
+        "client_id": config["client_id"],
+    })
+    token_data["access_token"] = resp["access_token"]
+    token_data["expires_at"] = time.time() + resp.get("expires_in", 3600)
+    if "refresh_token" in resp:
+        token_data["refresh_token"] = resp["refresh_token"]
+    _write_json(TOKEN_PATH, token_data)
+    return token_data
+
+
+def cmd_login(args):
+    client_id = args.client_id
+    if not client_id:
+        try:
+            config = _read_json(CONFIG_PATH)
+            client_id = config.get("client_id")
+        except (FileNotFoundError, json.JSONDecodeError):
+            pass
+    if not client_id:
+        print("Error: --client-id is required for first login", file=sys.stderr)
+        sys.exit(1)
+
+    _write_json(CONFIG_PATH, {"client_id": client_id, "redirect_uri": REDIRECT_URI})
+
+    verifier, challenge = _generate_pkce()
+    params = urllib.parse.urlencode({
+        "client_id": client_id,
+        "response_type": "code",
+        "redirect_uri": REDIRECT_URI,
+        "scope": SCOPES,
+        "code_challenge_method": "S256",
+        "code_challenge": challenge,
+    })
+    auth_url = f"{AUTH_URL}?{params}"
+
+    authorization_code = None
+
+    class CallbackHandler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            nonlocal authorization_code
+            qs = urllib.parse.urlparse(self.path).query
+            parsed = urllib.parse.parse_qs(qs)
+            if "error" in parsed:
+                self.send_response(400)
+                self.end_headers()
+                self.wfile.write(f"Error: {parsed['error'][0]}".encode())
+                return
+            authorization_code = parsed.get("code", [None])[0]
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html")
+            self.end_headers()
+            self.wfile.write(b"<h2>Authenticated! You can close this tab.</h2>")
+
+        def log_message(self, format, *args):
+            pass  # suppress request logging
+
+    print(f"Opening browser for Spotify authorization...")
+    webbrowser.open(auth_url)
+
+    server = http.server.HTTPServer(("localhost", 8765), CallbackHandler)
+    server.timeout = 120
+    server.handle_request()
+    server.server_close()
+
+    if not authorization_code:
+        print("Error: no authorization code received", file=sys.stderr)
+        sys.exit(1)
+
+    resp = _token_request({
+        "grant_type": "authorization_code",
+        "code": authorization_code,
+        "redirect_uri": REDIRECT_URI,
+        "client_id": client_id,
+        "code_verifier": verifier,
+    })
+
+    token_data = {
+        "access_token": resp["access_token"],
+        "refresh_token": resp["refresh_token"],
+        "expires_at": time.time() + resp.get("expires_in", 3600),
+    }
+    _write_json(TOKEN_PATH, token_data)
+    print("Login successful. Token saved.")
+
+
+def cmd_token(_args):
+    try:
+        config = _read_json(CONFIG_PATH)
+        token_data = _read_json(TOKEN_PATH)
+    except FileNotFoundError:
+        print("Error: not logged in. Run: spotify_auth.py login --client-id <ID>", file=sys.stderr)
+        sys.exit(1)
+
+    if time.time() >= token_data.get("expires_at", 0) - 60:
+        token_data = _refresh_token(config, token_data)
+
+    print(token_data["access_token"])
+
+
+def cmd_status(_args):
+    try:
+        _read_json(CONFIG_PATH)
+    except FileNotFoundError:
+        print("not configured")
+        return
+
+    try:
+        token_data = _read_json(TOKEN_PATH)
+    except FileNotFoundError:
+        print("configured but not logged in")
+        return
+
+    expires_at = token_data.get("expires_at", 0)
+    if time.time() >= expires_at:
+        print("authenticated (token expired, will refresh on next use)")
+    else:
+        remaining = int(expires_at - time.time())
+        print(f"authenticated (token valid for {remaining}s)")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Spotify OAuth2 PKCE auth helper")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    login_p = sub.add_parser("login", help="Authenticate with Spotify")
+    login_p.add_argument("--client-id", help="Spotify app client ID")
+
+    sub.add_parser("token", help="Print valid access token to stdout")
+    sub.add_parser("status", help="Show auth status")
+
+    args = parser.parse_args()
+    {"login": cmd_login, "token": cmd_token, "status": cmd_status}[args.command](args)
+
+
+if __name__ == "__main__":
+    main()

--- a/sptfy.md
+++ b/sptfy.md
@@ -1,0 +1,118 @@
+# sptfy — Spotify playlist CLI tool (future)
+
+Plan for a full Go CLI tool following the conventions in `~/dev`. Saved for posterity — the current approach uses a Claude Code skill instead.
+
+## Approach
+
+Build a Go CLI tool (`sptfy`) using Cobra, keychain auth, `~/.config/sptfy/`, Makefile + GoReleaser. Talks to the Spotify Web API via `github.com/zmb3/spotify/v2`.
+
+### Detection strategy (no hardcoded show names)
+
+Use generic heuristics:
+
+1. **Album type**: Spotify marks albums as `album`, `single`, or `compilation`. Radio show episodes are compilations.
+2. **Album track count**: Radio show albums have many tracks (20+) from diverse artists.
+3. **Title parentheticals**: Track titles contain show-like identifiers `(ASOT 1263)`, `(FYHTOP2025)` — NOT standard mix descriptors.
+4. **Composite signal**: A track flagged by any combination gets searched for standalone versions.
+
+### Replacement search strategy
+
+1. Strip the show-like parenthetical from the track title -> base song name.
+2. Identify the "real" artist(s).
+3. Search Spotify for: `"{base song name}" {artist}` — look for matches on non-compilation albums.
+4. Also try: `"{base song name} Extended Mix"`, `"{base song name} Radio Edit"`.
+5. Rank candidates: prefer extended mix > radio edit > original, prefer same artists, prefer non-compilation albums.
+
+## Commands
+
+```
+sptfy init                          # OAuth2 setup
+sptfy config show                   # Show current config
+sptfy config clear                  # Clear config + token
+
+sptfy playlists                     # List user's playlists
+sptfy tracks <playlist-name-or-id>  # List tracks in a playlist
+
+sptfy scan <playlist-name-or-id>    # Scan playlist, output plan JSON
+sptfy scan --all                    # Scan all user playlists
+
+sptfy search "<query>"              # Search Spotify for tracks
+
+sptfy replace <plan-file>           # Apply approved replacements from plan file
+```
+
+## Plan file format
+
+`sptfy scan` outputs a JSON file:
+
+```json
+{
+  "generated_at": "2026-02-22T10:30:00Z",
+  "playlist": {
+    "id": "abc123",
+    "name": "Electronica 2026"
+  },
+  "replacements": [
+    {
+      "action": "replace",
+      "original": {
+        "id": "spotify:track:xxx",
+        "name": "Dopamine Machine (ASOT 1263)",
+        "artists": ["Armin van Buuren", "Lilly Palmer"],
+        "album": "ASOT 1263 - A State of Trance Episode 1263",
+        "album_type": "compilation",
+        "position": 3,
+        "duration_ms": 144000
+      },
+      "candidates": [
+        {
+          "id": "spotify:track:yyy",
+          "name": "Dopamine Machine (Extended Mix)",
+          "artists": ["Lilly Palmer"],
+          "album": "Dopamine Machine",
+          "album_type": "single",
+          "duration_ms": 398000,
+          "selected": true
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Project structure
+
+```
+~/dev/spotify-cli/
+├── cmd/sptfy/main.go
+├── internal/
+│   ├── cmd/{root,initcmd,configcmd,playlists,tracks,scan,search,replace}/
+│   ├── auth/auth.go
+│   ├── config/config.go
+│   ├── keychain/
+│   ├── detector/detector.go
+│   ├── matcher/matcher.go
+│   ├── plan/plan.go
+│   ├── output/output.go
+│   └── version/version.go
+├── Makefile
+├── .goreleaser.yml
+└── go.mod
+```
+
+## Auth flow
+
+1. User creates Spotify Developer App at https://developer.spotify.com/dashboard
+2. Sets redirect URI to `http://localhost:8765/callback`
+3. Runs `sptfy init` — prompted for Client ID
+4. Browser opens for consent, local server catches callback
+5. Token stored in macOS Keychain (fallback: token.json)
+6. Auto-refreshes via PersistentTokenSource
+
+## Dependencies
+
+- `github.com/zmb3/spotify/v2`
+- `github.com/spf13/cobra`
+- `github.com/fatih/color`
+- `github.com/charmbracelet/huh`
+- `golang.org/x/oauth2`


### PR DESCRIPTION
## Summary

- **`spotify_auth.py`**: OAuth2 PKCE auth helper (stdlib only, no pip deps). Supports `login`, `token` (with auto-refresh), and `status` commands. Tokens stored in `~/.config/sptfy/` with 0600 perms.
- **`commands/spotify-scan.md`**: Custom command (`/spotify-scan`) that orchestrates Spotify API calls to scan playlists for radio show compilation tracks and propose standalone replacement swaps interactively.
- **`Makefile`**: `make install` symlinks the command into `~/.claude/commands/` and creates the config directory. `make uninstall` reverses it.
- **`sptfy.md`**: Go CLI tool plan saved for future reference.

## Setup

1. Create a Spotify Developer App at https://developer.spotify.com/dashboard
2. Set redirect URI to `http://localhost:8765/callback`
3. `make install`
4. `python3 spotify_auth.py login --client-id <CLIENT_ID>`
5. `/spotify-scan Electronica 2026`

Closes #1